### PR TITLE
Check sampler state block parsing

### DIFF
--- a/lang/src/parser.lalrpop
+++ b/lang/src/parser.lalrpop
@@ -717,11 +717,11 @@ sampler_state_declaration: ast::SamplerState = {
 };
 
 declaration: ast::Declaration = {
+    <l:@L> <i:init_declarator_list> ";"  <r:@R> => ast::DeclarationData::InitDeclaratorList(i).spanned(l, r),
     <l:@L> <p:function_prototype> ";"    <r:@R> => {
         ctx.new_identifier(&p.name, IdentifierContext::FunctionPrototype);
         ast::DeclarationData::FunctionPrototype(p).spanned(l, r)
     },
-    <l:@L> <i:init_declarator_list> ";"  <r:@R> => ast::DeclarationData::InitDeclaratorList(i).spanned(l, r),
     <l:@L> <p:precision_declaration> ";" <r:@R> => p.spanned(l, r),
     <l:@L> <b:block_declaration> ";"     <r:@R> => ast::DeclarationData::Block(b).spanned(l, r),
     <l:@L> "invariant" <i:identifier> ";" <r:@R> => ast::DeclarationData::Invariant(i).spanned(l, r),
@@ -860,6 +860,10 @@ preprocessor: ast::Preprocessor = {
     <l:@L> "#version"   <p:preprocessor_version>   <r:@R> => ast::PreprocessorData::Version(p).spanned(l, r),
     <l:@L> "#extension" <p:preprocessor_extension> <r:@R> => ast::PreprocessorData::Extension(p).spanned(l, r),
 };
+
+
+
+
 
 external_declaration: Option<ast::ExternalDeclaration> = {
     <l:@L> <p:preprocessor> <r:@R>        => Some(ast::ExternalDeclarationData::Preprocessor(p).spanned(l, r)),


### PR DESCRIPTION
Reorder `declaration` rules in `parser.lalrpop` to fix parsing of `Texture2D` and other texture type declarations.

The parser was incorrectly attempting to parse `Texture2D` declarations as function prototypes, leading to a parse error. By prioritizing `init_declarator_list` within the `declaration` rule, the parser should correctly identify variable declarations before trying to match function prototypes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3a96b01-bdd9-42d7-8a53-d7f13b26fbfc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3a96b01-bdd9-42d7-8a53-d7f13b26fbfc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

