### PR TITLE
Investigate line number reporting discrepancy

### DIFF
--- a/lang/tests/shader_parsing.rs
+++ b/lang/tests/shader_parsing.rs
@@ -1,4 +1,5 @@
-use hlsl_lang::{ast, parse::DefaultParse};
+use hlsl_lang::{lexer::full::fs::PreprocessorExt, parse::IntoParseBuilderExt};
+use hlsl_lang_pp::processor::fs::StdProcessor;
 use std::fs;
 use std::path::Path;
 use std::collections::HashSet;
@@ -315,8 +316,17 @@ fn test_shader_parsing() {
             }
         };
 
-        // Try to parse the shader
-        match ast::TranslationUnit::parse(&source) {
+        // Try to parse the shader with preprocessor
+        let mut processor = StdProcessor::new();
+        match processor
+            .open_source(&source, path.parent().unwrap_or_else(|| Path::new(".")))
+            .builder()
+            .parse()
+            .map(|(mut tu, _, iter)| {
+                iter.into_directives().inject(&mut tu);
+                tu
+            })
+        {
             Ok(_) => {
                 println!("✓ Parsed successfully: {}", path_str);
                 actual_pass_shaders.push(path_str.to_string());
@@ -427,8 +437,17 @@ fn test_data_hlsl_parsing() {
                     }
                 };
 
-                // Try to parse the shader
-                match ast::TranslationUnit::parse(&source) {
+                // Try to parse the shader with preprocessor
+                let mut processor = StdProcessor::new();
+                match processor
+                    .open_source(&source, path.parent().unwrap_or_else(|| Path::new(".")))
+                    .builder()
+                    .parse()
+                    .map(|(mut tu, _, iter)| {
+                        iter.into_directives().inject(&mut tu);
+                        tu
+                    })
+                {
                     Ok(_) => {
                         actual_pass_shaders.push(file_name.to_string());
                     }


### PR DESCRIPTION
Update shader parsing tests to use preprocessor-based parsing for consistent line numbers in error messages.

The original issue was that the `shader_parsing.rs` tests reported raw line numbers, while the CLI tool reported line numbers adjusted by preprocessor directives (e.g., `#line`). This PR aligns the test's parsing mechanism with the CLI's by using `StdProcessor`, ensuring error messages in tests reflect the logical source position.

---
<a href="https://cursor.com/background-agent?bcId=bc-54e24312-44ba-4f84-bd5c-af6524f0dcd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54e24312-44ba-4f84-bd5c-af6524f0dcd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

